### PR TITLE
Add native HUD overlay preview sync

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -18,6 +18,10 @@ android {
         versionName "1.0"
     }
 
+    buildFeatures {
+        viewBinding true
+    }
+
     buildTypes {
         release {
             // ✅ Default Flutter signing config

--- a/android/app/src/main/kotlin/com/evenreality/g1app/hud/HudOverlay.kt
+++ b/android/app/src/main/kotlin/com/evenreality/g1app/hud/HudOverlay.kt
@@ -1,0 +1,60 @@
+package com.evenreality.g1app.hud
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.example.demo_ai_even.databinding.HudOverlayBinding
+import com.example.demo_ai_even.R
+
+/**
+ * Lightweight helper that attaches the HUD preview layout to the provided [container]
+ * and exposes a [render] method so native code can keep the preview in sync with Flutter.
+ */
+class HudOverlay(
+    context: Context,
+    private val container: ViewGroup,
+) {
+    private val binding = HudOverlayBinding.inflate(LayoutInflater.from(context), container, true)
+
+    /**
+     * Update the overlay UI using the latest [state].
+     */
+    fun render(state: HudOverlayState) {
+        val hasText = !state.text.isNullOrBlank()
+        val shouldShow = state.isActive && hasText
+
+        val visibility = if (shouldShow) View.VISIBLE else View.GONE
+        container.visibility = visibility
+        binding.root.visibility = visibility
+
+        if (!shouldShow) {
+            binding.hudMessage.text = ""
+            binding.pageIndicator.visibility = View.GONE
+            binding.countdown.visibility = View.GONE
+            return
+        }
+
+        binding.hudMessage.text = state.text
+
+        val pageText = state.pageIndicator
+        binding.pageIndicator.text = pageText
+        binding.pageIndicator.visibility = if (pageText.isNullOrBlank()) View.GONE else View.VISIBLE
+
+        val countdown = state.countdownSeconds
+        when {
+            countdown != null && countdown > 0 -> {
+                binding.countdown.text = container.context.getString(R.string.hud_overlay_countdown, countdown)
+                binding.countdown.visibility = View.VISIBLE
+            }
+            state.isManualMode -> {
+                binding.countdown.text = container.context.getString(R.string.hud_overlay_manual)
+                binding.countdown.visibility = View.VISIBLE
+            }
+            else -> {
+                binding.countdown.text = ""
+                binding.countdown.visibility = View.GONE
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/evenreality/g1app/hud/HudOverlayState.kt
+++ b/android/app/src/main/kotlin/com/evenreality/g1app/hud/HudOverlayState.kt
@@ -1,0 +1,46 @@
+package com.evenreality.g1app.hud
+
+/**
+ * Represents the data that should be rendered inside the HUD preview overlay.
+ */
+data class HudOverlayState(
+    val isActive: Boolean,
+    val text: String?,
+    val pageIndicator: String?,
+    val countdownSeconds: Int?,
+    val isManualMode: Boolean
+) {
+    companion object {
+        val Hidden = HudOverlayState(
+            isActive = false,
+            text = null,
+            pageIndicator = null,
+            countdownSeconds = null,
+            isManualMode = false,
+        )
+
+        fun fromMap(raw: Map<*, *>?): HudOverlayState {
+            if (raw == null) return Hidden
+
+            val isActive = raw["isActive"] as? Boolean ?: false
+            val text = raw["text"] as? String
+            val pageIndicator = raw["page"] as? String
+            val isManual = raw["isManual"] as? Boolean ?: false
+
+            val countdownValue = raw["countdown"] ?: raw["countdownSeconds"]
+            val countdownSeconds = when (countdownValue) {
+                is Number -> countdownValue.toInt()
+                is String -> countdownValue.toIntOrNull()
+                else -> null
+            }
+
+            return HudOverlayState(
+                isActive = isActive,
+                text = text,
+                pageIndicator = pageIndicator,
+                countdownSeconds = countdownSeconds,
+                isManualMode = isManual,
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/example/demo_ai_even/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/demo_ai_even/MainActivity.kt
@@ -3,9 +3,13 @@ package com.example.demo_ai_even
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.view.ViewGroup
+import android.widget.FrameLayout
 import com.example.demo_ai_even.bluetooth.BleChannelHelper
 import com.example.demo_ai_even.bluetooth.BleManager
 import com.example.demo_ai_even.cpp.Cpp
+import com.evenreality.g1app.hud.HudOverlay
+import com.evenreality.g1app.hud.HudOverlayState
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.EventChannel
@@ -14,11 +18,15 @@ import io.flutter.plugin.common.MethodChannel
 class MainActivity: FlutterActivity(), EventChannel.StreamHandler {
 
     private val SERVICE_CHANNEL = "com.example.demo_ai_even/ble_service"
+    private val HUD_CHANNEL = "com.example.demo_ai_even/hud_preview"
+
+    private var hudOverlay: HudOverlay? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Cpp.init()
         BleManager.instance.initBluetooth(this)
+        ensureHudOverlay()
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -46,6 +54,50 @@ class MainActivity: FlutterActivity(), EventChannel.StreamHandler {
                     else -> result.notImplemented()
                 }
             }
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, HUD_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "render" -> {
+                        val state = HudOverlayState.fromMap(call.arguments as? Map<*, *>)
+                        renderHud(state)
+                        result.success(null)
+                    }
+                    "hide" -> {
+                        renderHud(HudOverlayState.Hidden)
+                        result.success(null)
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+    }
+
+    private fun ensureHudOverlay(): HudOverlay {
+        hudOverlay?.let { return it }
+
+        val root = findViewById<ViewGroup>(android.R.id.content)
+            ?: (window.decorView as? ViewGroup
+                ?: throw IllegalStateException("Unable to locate activity content view for HUD overlay"))
+        val container = FrameLayout(this).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+            )
+            setBackgroundColor(android.graphics.Color.TRANSPARENT)
+            isClickable = false
+            isFocusable = false
+        }
+        root.addView(container)
+
+        return HudOverlay(this, container).also {
+            it.render(HudOverlayState.Hidden)
+            hudOverlay = it
+        }
+    }
+
+    private fun renderHud(state: HudOverlayState) {
+        Log.d(this::class.simpleName, "HUD preview update: $state")
+        ensureHudOverlay().render(state)
     }
 
     // 🔹 EventChannel: for streaming BLE events into Flutter

--- a/android/app/src/main/res/drawable/hud_overlay_background.xml
+++ b/android/app/src/main/res/drawable/hud_overlay_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#CC000000" />
+    <stroke
+        android:width="1dp"
+        android:color="#4D00FFAA" />
+    <corners android:radius="16dp" />
+    <padding
+        android:left="4dp"
+        android:top="4dp"
+        android:right="4dp"
+        android:bottom="4dp" />
+</shape>

--- a/android/app/src/main/res/layout/hud_overlay.xml
+++ b/android/app/src/main/res/layout/hud_overlay.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/hudOverlayRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:visibility="gone">
+
+    <LinearLayout
+        android:id="@+id/hudOverlayContent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|center_horizontal"
+        android:orientation="vertical"
+        android:background="@drawable/hud_overlay_background"
+        android:padding="16dp"
+        android:elevation="4dp">
+
+        <TextView
+            android:id="@+id/hudMessage"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="#00FFAA"
+            android:textSize="16sp"
+            android:fontFamily="sans-serif-medium"
+            android:lineSpacingExtra="4dp"
+            android:maxLines="6" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <TextView
+                android:id="@+id/pageIndicator"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textColor="#B3FFFFFF"
+                android:textSize="12sp"
+                android:fontFamily="sans-serif"
+                android:visibility="gone" />
+
+            <TextView
+                android:id="@+id/countdown"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="#B3FFFFFF"
+                android:textSize="12sp"
+                android:fontFamily="sans-serif"
+                android:visibility="gone"
+                android:layout_marginStart="12dp" />
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="hud_overlay_countdown">Next in %1$ds</string>
+    <string name="hud_overlay_manual">Manual mode</string>
+</resources>

--- a/lib/widgets/hud_overlay.dart
+++ b/lib/widgets/hud_overlay.dart
@@ -1,6 +1,8 @@
 // lib/widgets/hud_overlay.dart
 import 'dart:async';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import '../services/gesture_handler.dart';
 import '../services/notification_service.dart';
@@ -23,6 +25,9 @@ class _HUDOverlayState extends State<HUDOverlay> {
   int _charIndex = 0;
   int _countdown = 0;
   bool _isManual = false; // ✅ track manual control
+
+  static const MethodChannel _hudPreviewChannel =
+      MethodChannel('com.example.demo_ai_even/hud_preview');
 
   @override
   void initState() {
@@ -66,6 +71,10 @@ class _HUDOverlayState extends State<HUDOverlay> {
     _pages = _paginate(text);
     _currentPage = 0;
     _isManual = false;
+    if (_pages.isEmpty) {
+      _hideHUD();
+      return;
+    }
     _startPage(_pages[_currentPage]);
     setState(() => _opacity = 1.0); // fade in
   }
@@ -88,10 +97,17 @@ class _HUDOverlayState extends State<HUDOverlay> {
         if (!_isManual) _startCountdown(_estimateTime(pageText));
       }
     });
+
+    _syncNativeHud(isActive: true, text: pageText);
   }
 
   void _startCountdown(int seconds) {
     _countdown = seconds;
+    _syncNativeHud(
+      isActive: true,
+      text: _pages[_currentPage],
+      countdown: _countdown,
+    );
     _countdownTimer?.cancel();
     _countdownTimer = Timer.periodic(const Duration(seconds: 1), (t) {
       if (_countdown <= 0) {
@@ -103,6 +119,11 @@ class _HUDOverlayState extends State<HUDOverlay> {
         }
       } else {
         setState(() => _countdown--);
+        _syncNativeHud(
+          isActive: true,
+          text: _pages[_currentPage],
+          countdown: _countdown,
+        );
       }
     });
   }
@@ -143,6 +164,7 @@ class _HUDOverlayState extends State<HUDOverlay> {
       _currentPage = 0;
       _isManual = false;
     });
+    _syncNativeHud(isActive: false);
   }
 
   @override
@@ -150,6 +172,43 @@ class _HUDOverlayState extends State<HUDOverlay> {
     _textTimer?.cancel();
     _countdownTimer?.cancel();
     super.dispose();
+  }
+
+  Future<void> _notifyNativeHud({
+    required bool isActive,
+    String? text,
+    int? countdown,
+  }) async {
+    final payload = <String, dynamic>{
+      'isActive': isActive,
+      'text': text,
+      'page': _pages.isEmpty ? null : '${_currentPage + 1}/${_pages.length}',
+      'countdown': countdown,
+      'isManual': _isManual,
+    }..removeWhere((key, value) => value == null);
+
+    try {
+      await _hudPreviewChannel.invokeMethod('render', payload);
+    } on MissingPluginException {
+      // Not running on Android; ignore.
+    } catch (e) {
+      debugPrint('HUD preview invoke failed: $e');
+    }
+  }
+
+  void _syncNativeHud({
+    required bool isActive,
+    String? text,
+    int? countdown,
+  }) {
+    final message = isActive ? text ?? (_pages.isNotEmpty ? _pages[_currentPage] : null) : null;
+    unawaited(
+      _notifyNativeHud(
+        isActive: isActive,
+        text: message,
+        countdown: countdown,
+      ),
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- enable view binding in the Android module and add a native HUD overlay layout/background
- implement `HudOverlay`/`HudOverlayState` plus a new `hud_preview` MethodChannel in `MainActivity` so preview visibility toggles correctly with EvenAI text
- forward HUD state changes from the Flutter widget to Android so countdowns and manual mode are rendered in the preview

## Testing
- `flutter test` *(fails: `flutter` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccac297ed08332b0129da9be08bc43