### PR TITLE
Enable CMake build for lc3 native library

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -16,6 +16,12 @@ android {
         targetSdk 34  // ✅ Match compileSdk
         versionCode 1
         versionName "1.0"
+
+        externalNativeBuild {
+            cmake {
+                // Additional flags can be provided here if needed
+            }
+        }
     }
 
     buildFeatures {
@@ -29,6 +35,20 @@ android {
             shrinkResources false
             minifyEnabled false
             // If you add ProGuard / R8 later, update rules here
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path "src/main/cpp/CMakeLists.txt"
+        }
+    }
+
+    ndkVersion flutter.ndkVersion
+
+    packaging {
+        jniLibs {
+            keepDebugSymbols += ["**/liblc3.so"]
         }
     }
 


### PR DESCRIPTION
## Summary
- configure the Android Gradle build to invoke the CMake project in src/main/cpp
- hook up defaultConfig and packaging so the generated liblc3.so is kept in the APK
- align the project with the Flutter-provided NDK version for native builds

## Testing
- gradle assembleRelease *(fails: missing Flutter SDK/local.properties in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb5049ad883329eb471f41b138475