### PR TITLE
Add tools namespace to Android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.example.demo_ai_even"> <!-- ✅ Match Kotlin package path -->
 
     <!-- 🔹 Bluetooth Permissions (required for flutter_blue_plus) -->


### PR DESCRIPTION
## Summary
- add the tools XML namespace declaration to the Android manifest so `tools:` attributes resolve correctly

## Testing
- `flutter build apk` *(fails: `flutter` command not found in container)*
- `./gradlew app:assembleDebug` *(fails: Gradle wrapper script is absent in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb4fcd58c8332ac03b3266f57b433